### PR TITLE
estates/<id>/buildings

### DIFF
--- a/src/ume-app-estateservice/Umea.se.EstateService.API/ApiRoutes.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.API/ApiRoutes.cs
@@ -8,4 +8,5 @@ public class ApiRoutes : ApiRoutesBase
     public const string Buildings = $"{RoutePrefixV1}/buildings";
     public const string Workspaces = $"{RoutePrefixV1}/workspaces";
     public const string Autocomplete = $"{RoutePrefixV1}/autocomplete";
+    public const string EstateBuildings = $"{Estates}/{{estateId:int}}/buildings";
 }

--- a/src/ume-app-estateservice/Umea.se.EstateService.API/Controllers/EstateController.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.API/Controllers/EstateController.cs
@@ -25,6 +25,15 @@ public class EstateController(IPythagorasHandler pythagorasService) : Controller
         return estates;
     }
 
+    [HttpGet("{estateId:int}/buildings")]
+    public async Task<IReadOnlyList<BuildingInfoModel>> GetEstateBuildingsAsync(int estateId, CancellationToken cancellationToken)
+    {
+        IReadOnlyList<BuildingInfoModel> buildings = await pythagorasService
+            .GetBuildingInfoAsync(null, estateId, cancellationToken);
+
+        return buildings;
+    }
+
     private static PythagorasQuery<NavigationFolder> BuildQuery(EstateRequest request)
     {
         PythagorasQuery<NavigationFolder> query = new PythagorasQuery<NavigationFolder>()

--- a/src/ume-app-estateservice/Umea.se.EstateService.Logic/Interfaces/IPythagorasHandler.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.Logic/Interfaces/IPythagorasHandler.cs
@@ -9,6 +9,8 @@ public interface IPythagorasHandler
 {
     Task<IReadOnlyList<BuildingModel>> GetBuildingsAsync(PythagorasQuery<Building>? query = null, CancellationToken cancellationToken = default);
 
+    Task<IReadOnlyList<BuildingInfoModel>> GetBuildingInfoAsync(PythagorasQuery<BuildingInfo>? query = null, int? navigationFolderId = null, CancellationToken cancellationToken = default);
+
     IAsyncEnumerable<BuildingModel> GetPaginatedBuildingsAsync(PythagorasQuery<Building>? query = null, int pageSize = 50, CancellationToken cancellationToken = default);
 
     Task<IReadOnlyList<BuildingWorkspaceModel>> GetBuildingWorkspacesAsync(int buildingId, PythagorasQuery<BuildingWorkspace>? query = null, CancellationToken cancellationToken = default);

--- a/src/ume-app-estateservice/Umea.se.EstateService.Logic/Mappers/PythagorasBuildingInfoMapper.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.Logic/Mappers/PythagorasBuildingInfoMapper.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Umea.se.EstateService.ServiceAccess.Pythagoras.Dto;
+using Umea.se.EstateService.ServiceAccess.Pythagoras.Enum;
+using Umea.se.EstateService.Shared.Models;
+using Umea.se.EstateService.Shared.ValueObjects;
+using TransportMarkerType = Umea.se.EstateService.ServiceAccess.Pythagoras.Enum.PythMarkerType;
+
+namespace Umea.se.EstateService.Logic.Mappers;
+
+public static class PythagorasBuildingInfoMapper
+{
+    public static BuildingInfoModel ToModel(BuildingInfo dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        return new BuildingInfoModel
+        {
+            Id = dto.Id,
+            Uid = dto.Uid,
+            Name = dto.Name ?? string.Empty,
+            PopularName = dto.PopularName ?? string.Empty,
+            MarkerType = ToModel(dto.MarkerType),
+            GeoLocation = CreateGeoPoint(dto),
+            GrossArea = dto.Grossarea ?? 0m,
+            NetArea = dto.Netarea ?? 0m,
+            SumGrossFloorArea = dto.SumGrossFloorarea ?? 0m,
+            NumPlacedPersons = dto.NumPlacedPersons,
+            AddressName = dto.AddressName ?? string.Empty,
+            Address = CreateAddress(dto),
+            Origin = dto.Origin ?? string.Empty,
+            CurrencyId = dto.CurrencyId,
+            CurrencyName = dto.CurrencyName,
+            FlagStatusIds = dto.FlagStatusIds?.ToArray() ?? Array.Empty<int>(),
+            BusinessTypeId = dto.BusinessTypeId,
+            BusinessTypeName = dto.BusinessTypeName,
+            ProspectOfBuildingId = dto.ProspectOfBuildingId,
+            IsProspect = dto.IsProspect,
+            ProspectStartDate = dto.ProspectStartDate,
+            ExtraInfo = ToDictionary(dto.ExtraInfo),
+            PropertyValues = ToDictionary(dto.PropertyValues),
+            NavigationInfo = ToDictionary(dto.NavigationInfo)
+        };
+    }
+
+    public static IReadOnlyList<BuildingInfoModel> ToModel(IReadOnlyList<BuildingInfo> dtos)
+    {
+        ArgumentNullException.ThrowIfNull(dtos);
+
+        return dtos.Count == 0
+            ? Array.Empty<BuildingInfoModel>()
+            : dtos.Select(ToModel).ToArray();
+    }
+
+    private static MarkerTypeEnum ToModel(TransportMarkerType markerType)
+    {
+        int numeric = (int)markerType;
+        if (Enum.IsDefined(typeof(MarkerTypeEnum), numeric))
+        {
+            return (MarkerTypeEnum)numeric;
+        }
+
+        return MarkerTypeEnum.Unknown;
+    }
+
+    private static GeoPointModel? CreateGeoPoint(BuildingInfo dto)
+    {
+        double x = dto.GeoX;
+        double y = dto.GeoY;
+        double rotation = dto.GeoRotation;
+
+        if (Math.Abs(x) < double.Epsilon && Math.Abs(y) < double.Epsilon)
+        {
+            return null;
+        }
+
+        return new GeoPointModel(x, y, rotation);
+    }
+
+    private static AddressModel CreateAddress(BuildingInfo dto)
+    {
+        bool hasAddress = !string.IsNullOrWhiteSpace(dto.AddressStreet)
+            || !string.IsNullOrWhiteSpace(dto.AddressZipCode)
+            || !string.IsNullOrWhiteSpace(dto.AddressCity)
+            || !string.IsNullOrWhiteSpace(dto.AddressCountry)
+            || !string.IsNullOrWhiteSpace(dto.AddressExtra);
+
+        if (!hasAddress)
+        {
+            return AddressModel.Empty;
+        }
+
+        return new AddressModel(
+            dto.AddressStreet ?? string.Empty,
+            dto.AddressZipCode ?? string.Empty,
+            dto.AddressCity ?? string.Empty,
+            dto.AddressCountry ?? string.Empty,
+            dto.AddressExtra ?? string.Empty);
+    }
+
+    private static IReadOnlyDictionary<string, string?> ToDictionary(Dictionary<string, string?>? source)
+    {
+        if (source is null || source.Count == 0)
+        {
+            return new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        return source.ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/src/ume-app-estateservice/Umea.se.EstateService.Logic/Mappers/PythagorasBuildingInfoMapper.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.Logic/Mappers/PythagorasBuildingInfoMapper.cs
@@ -78,7 +78,7 @@ public static class PythagorasBuildingInfoMapper
         return new GeoPointModel(x, y, rotation);
     }
 
-    private static AddressModel CreateAddress(BuildingInfo dto)
+    private static AddressModel? CreateAddress(BuildingInfo dto)
     {
         bool hasAddress = !string.IsNullOrWhiteSpace(dto.AddressStreet)
             || !string.IsNullOrWhiteSpace(dto.AddressZipCode)
@@ -88,7 +88,7 @@ public static class PythagorasBuildingInfoMapper
 
         if (!hasAddress)
         {
-            return AddressModel.Empty;
+            return null;
         }
 
         return new AddressModel(

--- a/src/ume-app-estateservice/Umea.se.EstateService.Logic/Mappers/PythagorasEstateMapper.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.Logic/Mappers/PythagorasEstateMapper.cs
@@ -13,13 +13,11 @@ public static class PythagorasEstateMapper
         return new EstateModel
         {
             Id = dto.Id,
-            NavigationId = dto.NavigationId,
             Uid = dto.Uid,
             Name = dto.Name ?? string.Empty,
             PopularName = dto.PopularName ?? string.Empty,
             GrossArea = dto.Grossarea ?? 0m,
             NetArea = dto.Netarea ?? 0m,
-            NavigationName = dto.NavigationName ?? string.Empty,
             GeoLocation = new GeoPointModel(dto.GeoX, dto.GeoY, dto.GeoRotation),
             Address = CreateAddress(dto),
         };
@@ -34,7 +32,7 @@ public static class PythagorasEstateMapper
             : dtos.Select(ToModel).ToArray();
     }
 
-    private static AddressModel CreateAddress(NavigationFolder dto)
+    private static AddressModel? CreateAddress(NavigationFolder dto)
     {
         bool hasValue =
             !string.IsNullOrWhiteSpace(dto.AddressStreet)
@@ -45,7 +43,7 @@ public static class PythagorasEstateMapper
 
         if (!hasValue)
         {
-            return AddressModel.Empty;
+            return null;
         }
 
         return new AddressModel(

--- a/src/ume-app-estateservice/Umea.se.EstateService.ServiceAccess/Pythagoras/Dto/BuildingInfo.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.ServiceAccess/Pythagoras/Dto/BuildingInfo.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using Umea.se.EstateService.ServiceAccess.Pythagoras.Enum;
+
+namespace Umea.se.EstateService.ServiceAccess.Pythagoras.Dto;
+
+public sealed class BuildingInfo
+{
+    public int Id { get; init; }
+    public Guid Uid { get; init; }
+    public string Name { get; init; } = string.Empty;
+    public string PopularName { get; init; } = string.Empty;
+    public decimal? Grossarea { get; init; }
+    public decimal? Netarea { get; init; }
+    public decimal? SumGrossFloorarea { get; init; }
+    public int NumPlacedPersons { get; init; }
+    public PythMarkerType MarkerType { get; init; }
+    public double GeoX { get; init; }
+    public double GeoY { get; init; }
+    public double GeoRotation { get; init; }
+    public string AddressName { get; init; } = string.Empty;
+    public string AddressCity { get; init; } = string.Empty;
+    public string AddressCountry { get; init; } = string.Empty;
+    public string AddressStreet { get; init; } = string.Empty;
+    public string AddressZipCode { get; init; } = string.Empty;
+    public string AddressExtra { get; init; } = string.Empty;
+    public string Origin { get; init; } = string.Empty;
+    public int? CurrencyId { get; init; }
+    public string? CurrencyName { get; init; }
+    public IReadOnlyList<int> FlagStatusIds { get; init; } = Array.Empty<int>();
+    public int? BusinessTypeId { get; init; }
+    public string? BusinessTypeName { get; init; }
+    public int? ProspectOfBuildingId { get; init; }
+    public bool IsProspect { get; init; }
+    public long? ProspectStartDate { get; init; }
+    public Dictionary<string, string?> ExtraInfo { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+    public Dictionary<string, string?> PropertyValues { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+    public Dictionary<string, string?> NavigationInfo { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+}

--- a/src/ume-app-estateservice/Umea.se.EstateService.ServiceAccess/Pythagoras/Enum/NavigationFolderType.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.ServiceAccess/Pythagoras/Enum/NavigationFolderType.cs
@@ -2,5 +2,11 @@
 
 public static class NavigationFolderType
 {
-    public const int Estate = 5;
+    public const int Toplevel = 2;          // Toppnivå
+    public const int Locality = 3;          // Ort
+    public const int Estate = 5;            // Fastighet
+    public const int District = 9;          // Distrikt
+    public const int Municipality = 12;     // Kommun
+    public const int SubMunicipality = 13;  // Kommundel
+    public const int ManagementObject = 14; // Förvaltningsobjekt
 }

--- a/src/ume-app-estateservice/Umea.se.EstateService.ServiceAccess/Pythagoras/Enum/NavigationType.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.ServiceAccess/Pythagoras/Enum/NavigationType.cs
@@ -1,0 +1,7 @@
+﻿namespace Umea.se.EstateService.ServiceAccess.Pythagoras.Enum;
+
+public static class NavigationType
+{
+    public const int UmeaKommun = 2;
+    public const int SpaceManager = 3;
+}

--- a/src/ume-app-estateservice/Umea.se.EstateService.Shared/Models/BuildingInfoModel.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.Shared/Models/BuildingInfoModel.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Umea.se.EstateService.Shared.ValueObjects;
+
+namespace Umea.se.EstateService.Shared.Models;
+
+public sealed class BuildingInfoModel
+{
+    public int Id { get; init; }
+    public Guid Uid { get; init; }
+    public string Name { get; init; } = string.Empty;
+    public string PopularName { get; init; } = string.Empty;
+    public MarkerTypeEnum MarkerType { get; init; }
+    public GeoPointModel? GeoLocation { get; init; }
+    public decimal GrossArea { get; init; }
+    public decimal NetArea { get; init; }
+    public decimal SumGrossFloorArea { get; init; }
+    public int NumPlacedPersons { get; init; }
+    public string AddressName { get; init; } = string.Empty;
+    public AddressModel Address { get; init; } = AddressModel.Empty;
+    public string Origin { get; init; } = string.Empty;
+    public int? CurrencyId { get; init; }
+    public string? CurrencyName { get; init; }
+    public IReadOnlyList<int> FlagStatusIds { get; init; } = Array.Empty<int>();
+    public int? BusinessTypeId { get; init; }
+    public string? BusinessTypeName { get; init; }
+    public int? ProspectOfBuildingId { get; init; }
+    public bool IsProspect { get; init; }
+    public long? ProspectStartDate { get; init; }
+    public IReadOnlyDictionary<string, string?> ExtraInfo { get; init; } = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+    public IReadOnlyDictionary<string, string?> PropertyValues { get; init; } = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+    public IReadOnlyDictionary<string, string?> NavigationInfo { get; init; } = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+
+    [MemberNotNullWhen(true, nameof(GeoLocation))]
+    public bool HasGeoLocation => GeoLocation is not null;
+}

--- a/src/ume-app-estateservice/Umea.se.EstateService.Shared/Models/BuildingInfoModel.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.Shared/Models/BuildingInfoModel.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Umea.se.EstateService.Shared.ValueObjects;
 
@@ -18,7 +16,7 @@ public sealed class BuildingInfoModel
     public decimal SumGrossFloorArea { get; init; }
     public int NumPlacedPersons { get; init; }
     public string AddressName { get; init; } = string.Empty;
-    public AddressModel Address { get; init; } = AddressModel.Empty;
+    public AddressModel? Address { get; init; }
     public string Origin { get; init; } = string.Empty;
     public int? CurrencyId { get; init; }
     public string? CurrencyName { get; init; }

--- a/src/ume-app-estateservice/Umea.se.EstateService.Shared/Models/EstateModel.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.Shared/Models/EstateModel.cs
@@ -10,8 +10,6 @@ public sealed class EstateModel
     public string PopularName { get; init; } = string.Empty;
     public decimal GrossArea { get; init; }
     public decimal NetArea { get; init; }
-    public int NavigationId { get; init; }
-    public string NavigationName { get; init; } = string.Empty;
     public GeoPointModel? GeoLocation { get; init; }
-    public AddressModel Address { get; init; } = AddressModel.Empty;
+    public AddressModel? Address { get; init; }
 }

--- a/src/ume-app-estateservice/Umea.se.EstateService.Test/Pythagoras/EstateControllerTests.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.Test/Pythagoras/EstateControllerTests.cs
@@ -1,0 +1,76 @@
+using Umea.se.EstateService.API.Controllers;
+using Umea.se.EstateService.Logic.Handlers;
+using Umea.se.EstateService.ServiceAccess.Pythagoras.Api;
+using Umea.se.EstateService.ServiceAccess.Pythagoras.Dto;
+using Umea.se.EstateService.Shared.Models;
+
+namespace Umea.se.EstateService.Test.Pythagoras;
+
+public class EstateControllerTests
+{
+    [Fact]
+    public async Task GetEstateBuildingsAsync_ReturnsFilteredBuildingsByEstateId()
+    {
+        FakePythagorasClient client = new()
+        {
+            GetAsyncResult =
+            [
+                new() { Id = 10, Name = "Building A" },
+                new() { Id = 11, Name = "Building B" }
+            ]
+        };
+
+        PythagorasHandler service = new(client);
+        EstateController controller = new(service);
+
+        IReadOnlyList<BuildingInfoModel> buildings = await controller.GetEstateBuildingsAsync(123, CancellationToken.None);
+
+        buildings.Count.ShouldBe(2);
+        buildings.Select(b => b.Id).ShouldBe(new[] { 10, 11 });
+        client.LastQueryString.ShouldNotBeNull();
+        client.LastQueryString.ShouldContain("navigationFolderId=123");
+        client.LastEndpoint.ShouldBe("rest/v1/building");
+    }
+
+    [Fact]
+    public async Task GetEstateBuildingsAsync_WithZeroResults_ReturnsEmptyList()
+    {
+        FakePythagorasClient client = new()
+        {
+            GetAsyncResult = []
+        };
+
+        PythagorasHandler service = new(client);
+        EstateController controller = new(service);
+
+        IReadOnlyList<BuildingInfoModel> buildings = await controller.GetEstateBuildingsAsync(456, CancellationToken.None);
+
+        buildings.ShouldBeEmpty();
+        client.LastQueryString.ShouldNotBeNull();
+        client.LastQueryString.ShouldContain("navigationFolderId=456");
+        client.LastEndpoint.ShouldBe("rest/v1/building");
+    }
+
+    private sealed class FakePythagorasClient : IPythagorasClient
+    {
+        public IReadOnlyList<Building> GetAsyncResult { get; set; } = [];
+        public string? LastQueryString { get; private set; }
+        public string? LastEndpoint { get; private set; }
+
+        public Task<IReadOnlyList<TDto>> GetAsync<TDto>(string endpoint, PythagorasQuery<TDto>? query, CancellationToken cancellationToken) where TDto : class
+        {
+            if (typeof(TDto) != typeof(Building))
+            {
+                throw new NotSupportedException("Test fake only supports Building DTOs.");
+            }
+
+            LastEndpoint = endpoint;
+            LastQueryString = query?.BuildAsQueryString();
+
+            return Task.FromResult((IReadOnlyList<TDto>)(object)GetAsyncResult);
+        }
+
+        public IAsyncEnumerable<TDto> GetPaginatedAsync<TDto>(string endpoint, PythagorasQuery<TDto>? query, int pageSize, CancellationToken cancellationToken) where TDto : class
+            => throw new NotSupportedException();
+    }
+}

--- a/src/ume-app-estateservice/Umea.se.EstateService.Test/Pythagoras/PythagorasBuildingInfoMapperTests.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.Test/Pythagoras/PythagorasBuildingInfoMapperTests.cs
@@ -1,0 +1,88 @@
+using Umea.se.EstateService.Logic.Mappers;
+using Umea.se.EstateService.ServiceAccess.Pythagoras.Dto;
+using Umea.se.EstateService.ServiceAccess.Pythagoras.Enum;
+using Umea.se.EstateService.Shared.Models;
+using Umea.se.EstateService.Shared.ValueObjects;
+
+namespace Umea.se.EstateService.Test.Pythagoras;
+
+public class PythagorasBuildingInfoMapperTests
+{
+    [Fact]
+    public void ToDomain_CopiesFields()
+    {
+        BuildingInfo dto = new()
+        {
+            Id = 5,
+            Uid = Guid.NewGuid(),
+            Name = "Info",
+            PopularName = "Popular",
+            MarkerType = PythMarkerType.Unknown,
+            Grossarea = 12.3m,
+            Netarea = 11.1m,
+            SumGrossFloorarea = 13.4m,
+            NumPlacedPersons = 7,
+            GeoX = 63.1,
+            GeoY = 20.2,
+            GeoRotation = 10.5,
+            AddressName = "Primary",
+            AddressStreet = "Main Street",
+            AddressZipCode = "12345",
+            AddressCity = "Town",
+            AddressCountry = "Country",
+            AddressExtra = "Extra",
+            Origin = "Source",
+            CurrencyId = 17,
+            CurrencyName = "SEK",
+            FlagStatusIds = new[] { 1, 2, 3 },
+            BusinessTypeId = 6,
+            BusinessTypeName = "Business",
+            ProspectOfBuildingId = 9,
+            IsProspect = true,
+            ProspectStartDate = 1000,
+            ExtraInfo = new() { ["key"] = "value" },
+            PropertyValues = new() { ["prop"] = "123" },
+            NavigationInfo = new() { ["nav"] = "info" }
+        };
+
+        BuildingInfoModel model = PythagorasBuildingInfoMapper.ToModel(dto);
+
+        model.Id.ShouldBe(dto.Id);
+        model.Uid.ShouldBe(dto.Uid);
+        model.Name.ShouldBe("Info");
+        model.PopularName.ShouldBe("Popular");
+        model.MarkerType.ShouldBe(MarkerTypeEnum.Unknown);
+        model.GrossArea.ShouldBe(dto.Grossarea ?? 0);
+        model.NetArea.ShouldBe(dto.Netarea ?? 0);
+        model.SumGrossFloorArea.ShouldBe(dto.SumGrossFloorarea ?? 0);
+        model.NumPlacedPersons.ShouldBe(dto.NumPlacedPersons);
+        model.AddressName.ShouldBe("Primary");
+        model.Address.ShouldBe(new AddressModel("Main Street", "12345", "Town", "Country", "Extra"));
+        model.Origin.ShouldBe(dto.Origin);
+        model.CurrencyId.ShouldBe(17);
+        model.CurrencyName.ShouldBe("SEK");
+        model.FlagStatusIds.ShouldBe(new[] { 1, 2, 3 });
+        model.BusinessTypeId.ShouldBe(6);
+        model.BusinessTypeName.ShouldBe("Business");
+        model.ProspectOfBuildingId.ShouldBe(9);
+        model.IsProspect.ShouldBeTrue();
+        model.ProspectStartDate.ShouldBe(1000);
+        model.GeoLocation.ShouldNotBeNull();
+        model.GeoLocation!.X.ShouldBe(dto.GeoX);
+        model.GeoLocation.Y.ShouldBe(dto.GeoY);
+        model.GeoLocation.Rotation.ShouldBe(dto.GeoRotation);
+        model.ExtraInfo.ContainsKey("key").ShouldBeTrue();
+        model.ExtraInfo["key"].ShouldBe("value");
+        model.PropertyValues.ContainsKey("prop").ShouldBeTrue();
+        model.PropertyValues["prop"].ShouldBe("123");
+        model.NavigationInfo.ContainsKey("nav").ShouldBeTrue();
+        model.NavigationInfo["nav"].ShouldBe("info");
+    }
+
+    [Fact]
+    public void ToDomain_WithEmptyCollection_ReturnsEmptyArray()
+    {
+        IReadOnlyList<BuildingInfoModel> result = PythagorasBuildingInfoMapper.ToModel([]);
+        result.ShouldBeSameAs(Array.Empty<BuildingInfoModel>());
+    }
+}


### PR DESCRIPTION
* Ny endpoint för att hämta buildings för en estate (`/estates/<id>/buildings`)
* Tog bort obselete-metoder
* La in alla typer av navigationsfoldrar i `NavigationFolderType`
* Ny klass `NavigationType` för de olika navigationsträden (UmeaKommun (2) / SpaceManager (3))
* Sätter navigationId = UmeaKommun för att undvika att det blir dubletter av byggnader då de verkar ligga i båda navigationsträden
