### PR TITLE
Refactor and modularize codebase

### DIFF
--- a/src/ume-app-estateservice/Umea.se.EstateService.Logic/Handlers/PythagorasHandler.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.Logic/Handlers/PythagorasHandler.cs
@@ -117,8 +117,6 @@ public class PythagorasHandler(IPythagorasClient pythagorasClient) : IPythagoras
         return mapper(payload);
     }
 
-    
-
     private static void ValidateSearchInputs(string searchTerm, int limit)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(searchTerm);

--- a/src/ume-app-estateservice/Umea.se.EstateService.Logic/Mappers/PythagorasEstateMapper.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.Logic/Mappers/PythagorasEstateMapper.cs
@@ -31,7 +31,7 @@ public static class PythagorasEstateMapper
 
         return dtos.Count == 0
             ? Array.Empty<EstateModel>()
-            : dtos.Select(ToModel).ToArray();
+            : [.. dtos.Select(ToModel)];
     }
 
     private static AddressModel CreateAddress(NavigationFolder dto)

--- a/src/ume-app-estateservice/Umea.se.EstateService.ServiceAccess/Pythagoras/Api/PythagorasClient.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.ServiceAccess/Pythagoras/Api/PythagorasClient.cs
@@ -18,16 +18,6 @@ public sealed class PythagorasClient(IHttpClientFactory httpClientFactory) : IPy
         return QueryAsync(endpoint, builder, cancellationToken);
     }
 
-    [Obsolete("Prefer overload accepting PythagorasQuery<T>.")]
-    public Task<IReadOnlyList<TDto>> GetOldAsync<TDto>(string endpoint, Action<PythagorasQuery<TDto>>? query = null, CancellationToken cancellationToken = default) where TDto : class
-    {
-        ArgumentNullException.ThrowIfNull(endpoint);
-
-        PythagorasQuery<TDto> builder = new();
-        query?.Invoke(builder);
-        return QueryAsync(endpoint, builder, cancellationToken);
-    }
-
     public async IAsyncEnumerable<TDto> GetPaginatedAsync<TDto>(string endpoint, PythagorasQuery<TDto>? query, int pageSize = 50, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         where TDto : class
     {
@@ -46,45 +36,6 @@ public sealed class PythagorasClient(IHttpClientFactory httpClientFactory) : IPy
             PythagorasQuery<TDto> pageQuery = baseQuery.Page(pageNumber, pageSize);
 
             IReadOnlyList<TDto> page = await QueryAsync(endpoint, pageQuery, cancellationToken).ConfigureAwait(false);
-            if (page.Count == 0)
-            {
-                yield break;
-            }
-
-            foreach (TDto item in page)
-            {
-                yield return item;
-            }
-
-            if (page.Count < pageSize)
-            {
-                yield break;
-            }
-
-            pageNumber++;
-        }
-    }
-
-    [Obsolete("Prefer overload accepting PythagorasQuery<T>.")]
-    public async IAsyncEnumerable<TDto> GetOldPaginatedAsync<TDto>(string endpoint, Action<PythagorasQuery<TDto>>? query = null, int pageSize = 50, [EnumeratorCancellation] CancellationToken cancellationToken = default)
-        where TDto : class
-    {
-        ArgumentNullException.ThrowIfNull(endpoint);
-
-        if (pageSize <= 0)
-        {
-            throw new ArgumentException("Page size must be > 0.", nameof(pageSize));
-        }
-
-        int pageNumber = 1;
-
-        while (true)
-        {
-            PythagorasQuery<TDto> builder = new();
-            query?.Invoke(builder);
-            builder.Page(pageNumber, pageSize);
-
-            IReadOnlyList<TDto> page = await QueryAsync(endpoint, builder, cancellationToken).ConfigureAwait(false);
             if (page.Count == 0)
             {
                 yield break;
@@ -133,7 +84,8 @@ public sealed class PythagorasClient(IHttpClientFactory httpClientFactory) : IPy
 
         if (Uri.TryCreate(trimmed, UriKind.RelativeOrAbsolute, out Uri? candidate)
             && candidate.IsAbsoluteUri
-            && (candidate.Scheme == Uri.UriSchemeHttp || candidate.Scheme == Uri.UriSchemeHttps))
+            && (candidate.Scheme == Uri.UriSchemeHttp
+            || candidate.Scheme == Uri.UriSchemeHttps))
         {
             return candidate.AbsoluteUri;
         }

--- a/src/ume-app-estateservice/Umea.se.EstateService.ServiceAccess/Pythagoras/Api/PythagorasQuery.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.ServiceAccess/Pythagoras/Api/PythagorasQuery.cs
@@ -1,29 +1,13 @@
-﻿namespace Umea.se.EstateService.ServiceAccess.Pythagoras.Api;
+﻿using System.Linq.Expressions;
+using Umea.se.EstateService.ServiceAccess.Pythagoras.Enum;
+using Umea.se.EstateService.ServiceAccess.Pythagoras.Helpers;
 
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Globalization;
-using System.Linq.Expressions;
-using System.Net.Http;
-using System.Reflection;
-using System.Text;
-using System.Text.Json;
-using System.Text.Json.Serialization;
-
+namespace Umea.se.EstateService.ServiceAccess.Pythagoras.Api;
 public enum FieldTarget { Parameter, Attribute }
-
-public enum Op
-{
-    Eq, Ne, Gt, Ge, Lt, Le,
-    LikeExact, LikeAnywhere, LikeStarts, LikeEnds,
-    ILikeExact, ILikeAnywhere, ILikeStarts, ILikeEnds
-}
 
 public class PythagorasQuery<T> where T : class
 {
     private readonly QueryRequest _req;
-    private static readonly ConcurrentDictionary<MemberInfo, string> _nameCache = new();
     private readonly bool _usedSkip;
     private readonly bool _usedTake;
     private readonly bool _usedPage;
@@ -75,15 +59,15 @@ public class PythagorasQuery<T> where T : class
             throw new ArgumentException($"The parameter name '{trimmedName}' is reserved and cannot be used.", nameof(name));
         }
 
-        string formattedValue = FormatValue(value);
+        string formattedValue = PythagorasQueryHelpers<T>.FormatValue(value);
         QueryRequest newReq = _req with { AdditionalParameters = _req.AdditionalParameters.SetItem(trimmedName, formattedValue) };
         return new PythagorasQuery<T>(newReq, _usedSkip, _usedTake, _usedPage);
     }
 
     public PythagorasQuery<T> Where<TProp>(Expression<Func<T, TProp>> selector, Op op, TProp value, FieldTarget target = FieldTarget.Parameter)
     {
-        string name = GetApiName(selector);
-        string str = FormatValue(value);
+        string name = PythagorasQueryHelpers<T>.GetApiName(selector);
+        string str = PythagorasQueryHelpers<T>.FormatValue(value);
         Filter filter = new(target, name, op, str);
         QueryRequest newReq = _req with { Filters = _req.Filters.Add(filter) };
         return new PythagorasQuery<T>(newReq, _usedSkip, _usedTake, _usedPage);
@@ -127,9 +111,9 @@ public class PythagorasQuery<T> where T : class
 
     public PythagorasQuery<T> Between<TProp>(Expression<Func<T, TProp>> s, TProp min, TProp max, FieldTarget target = FieldTarget.Parameter)
     {
-        string name = GetApiName(s);
-        Filter minFilter = new(target, name, Op.Ge, FormatValue(min));
-        Filter maxFilter = new(target, name, Op.Le, FormatValue(max));
+        string name = PythagorasQueryHelpers<T>.GetApiName(s);
+        Filter minFilter = new(target, name, Op.Ge, PythagorasQueryHelpers<T>.FormatValue(min));
+        Filter maxFilter = new(target, name, Op.Le, PythagorasQueryHelpers<T>.FormatValue(max));
 
         QueryRequest newReq = _req with { Filters = _req.Filters.AddRange([minFilter, maxFilter]) };
         return new PythagorasQuery<T>(newReq, _usedSkip, _usedTake, _usedPage);
@@ -143,13 +127,13 @@ public class PythagorasQuery<T> where T : class
 
     public PythagorasQuery<T> OrderBy<TProp>(Expression<Func<T, TProp>> s)
     {
-        QueryRequest newReq = _req with { OrderBy = new Order(GetApiName(s), true) };
+        QueryRequest newReq = _req with { OrderBy = new Order(PythagorasQueryHelpers<T>.GetApiName(s), true) };
         return new PythagorasQuery<T>(newReq, _usedSkip, _usedTake, _usedPage);
     }
 
     public PythagorasQuery<T> OrderByDescending<TProp>(Expression<Func<T, TProp>> s)
     {
-        QueryRequest newReq = _req with { OrderBy = new Order(GetApiName(s), false) };
+        QueryRequest newReq = _req with { OrderBy = new Order(PythagorasQueryHelpers<T>.GetApiName(s), false) };
         return new PythagorasQuery<T>(newReq, _usedSkip, _usedTake, _usedPage);
     }
 
@@ -234,285 +218,8 @@ public class PythagorasQuery<T> where T : class
 
         return new HttpRequestMessage(method, uriBuilder.Uri);
     }
-
-    // ---- Helpers ----
-
-    private static string GetApiName<TProp>(Expression<Func<T, TProp>> expr)
-    {
-        PropertyInfo mi = expr.Body switch
-        {
-            MemberExpression m when m.Member is PropertyInfo pi => pi,
-            UnaryExpression u when u.Operand is MemberExpression um && um.Member is PropertyInfo upi => upi,
-            _ => throw new ArgumentException($"Expression must be a property access on {typeof(T).Name}.", nameof(expr))
-        };
-
-        return _nameCache.GetOrAdd(mi, static m =>
-        {
-            JsonPropertyNameAttribute? json = m.GetCustomAttribute<JsonPropertyNameAttribute>();
-            return json?.Name ?? JsonNamingPolicy.CamelCase.ConvertName(m.Name);
-        });
-    }
-
-    private static string FormatValue<TProp>(TProp value)
-    {
-        if (value is null)
-        {
-            return string.Empty;
-        }
-
-        return value switch
-        {
-            DateTime dt => dt.Kind == DateTimeKind.Unspecified
-                ? DateTime.SpecifyKind(dt, DateTimeKind.Utc).ToString("o", CultureInfo.InvariantCulture)
-                : dt.ToString("o", CultureInfo.InvariantCulture),
-            DateTimeOffset dto => dto.ToString("o", CultureInfo.InvariantCulture),
-            bool b => b ? "true" : "false",
-            IFormattable f => f.ToString(null, CultureInfo.InvariantCulture) ?? string.Empty,
-            _ => value.ToString() ?? string.Empty
-        };
-    }
 }
 
 public sealed record Filter(FieldTarget Target, string Field, Op Operator, string Value);
 public sealed record Order(string Field, bool Asc = true);
 public sealed record Paging(int? FirstResult, int? MaxResults);
-
-public sealed record QueryRequest
-{
-    public ImmutableList<int> Ids { get; init; } = [];
-    public string? GeneralSearch { get; init; }
-    public ImmutableList<Filter> Filters { get; init; } = [];
-    public Order? OrderBy { get; init; }
-    public Paging? Page { get; init; }
-    public ImmutableDictionary<string, string> AdditionalParameters { get; init; } = ImmutableDictionary<string, string>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase);
-}
-
-public static class OperatorMaps
-{
-    private static readonly Dictionary<Op, string> _prefix = new()
-    {
-        [Op.Eq] = "EQ:",
-        [Op.Ne] = "NE:",
-        [Op.Gt] = "GT:",
-        [Op.Ge] = "GE:",
-        [Op.Lt] = "LT:",
-        [Op.Le] = "LE:",
-        [Op.LikeExact] = "LIKEEX:",
-        [Op.LikeAnywhere] = "LIKEAW:",
-        [Op.LikeStarts] = "LIKEST:",
-        [Op.LikeEnds] = "LIKEEN:",
-        [Op.ILikeExact] = "ILIKEEX:",
-        [Op.ILikeAnywhere] = "ILIKEAW:",
-        [Op.ILikeStarts] = "ILIKEST:",
-        [Op.ILikeEnds] = "ILIKEEN:",
-    };
-
-    public static string ToPrefix(Op op) => _prefix[op];
-
-    public static Op FromStringOrPrefix(string op)
-    {
-        string u = op.Trim().ToUpperInvariant().TrimEnd(':');
-        if (u.Length == 0)
-        {
-            throw new ArgumentException("Operator cannot be empty.", nameof(op));
-        }
-        return u switch
-        {
-            "EQ" or "==" or "=" => Op.Eq,
-            "NE" or "!=" => Op.Ne,
-            "GT" or ">" => Op.Gt,
-            "GE" or ">=" => Op.Ge,
-            "LT" or "<" => Op.Lt,
-            "LE" or "<=" => Op.Le,
-            "LIKEEX" => Op.LikeExact,
-            "LIKEAW" => Op.LikeAnywhere,
-            "LIKEST" => Op.LikeStarts,
-            "LIKEEN" => Op.LikeEnds,
-            "ILIKEEX" => Op.ILikeExact,
-            "ILIKEAW" => Op.ILikeAnywhere,
-            "ILIKEST" => Op.ILikeStarts,
-            "ILIKEEN" => Op.ILikeEnds,
-            _ => throw new ArgumentException($"Unknown or unsupported operator '{u}'.", nameof(op))
-        };
-    }
-}
-
-internal static class QueryStringWriter
-{
-    private static readonly HashSet<string> _reservedKeys = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "id[]", "generalSearch", "pN[]", "pV[]", "aN[]", "aV[]",
-        "orderBy", "orderAsc", "firstResult", "maxResults"
-    };
-
-    private static readonly HashSet<Op> _likeOps =
-    [
-        Op.LikeExact,
-        Op.LikeAnywhere,
-        Op.LikeStarts,
-        Op.LikeEnds,
-        Op.ILikeExact,
-        Op.ILikeAnywhere,
-        Op.ILikeStarts,
-        Op.ILikeEnds
-    ];
-
-    private static readonly HashSet<Op> _comparisonOps =
-    [
-        Op.Gt,
-        Op.Ge,
-        Op.Lt,
-        Op.Le
-    ];
-
-    internal static bool IsReservedKey(string key) => _reservedKeys.Contains(key);
-
-    internal static string Build(QueryRequest req)
-    {
-        Validate(req);
-
-        List<KeyValuePair<string, string>> parts = [];
-
-        foreach (int id in req.Ids)
-        {
-            parts.Add(new("id[]", id.ToString(CultureInfo.InvariantCulture)));
-        }
-
-        if (!string.IsNullOrWhiteSpace(req.GeneralSearch))
-        {
-            parts.Add(new("generalSearch", req.GeneralSearch!));
-        }
-
-        foreach (Filter f in req.Filters)
-        {
-            string prefixedName = $"{OperatorMaps.ToPrefix(f.Operator)}{f.Field}";
-            if (f.Target == FieldTarget.Parameter)
-            {
-                parts.Add(new("pN[]", prefixedName));
-                parts.Add(new("pV[]", f.Value));
-            }
-            else
-            {
-                parts.Add(new("aN[]", prefixedName));
-                parts.Add(new("aV[]", f.Value));
-            }
-        }
-
-        if (req.OrderBy is not null)
-        {
-            parts.Add(new("orderBy", req.OrderBy.Field));
-            parts.Add(new("orderAsc", req.OrderBy.Asc ? "true" : "false"));
-        }
-
-        if (req.Page is not null)
-        {
-            if (req.Page.FirstResult is int fr)
-            {
-                parts.Add(new("firstResult", fr.ToString(CultureInfo.InvariantCulture)));
-            }
-
-            if (req.Page.MaxResults is int mr)
-            {
-                parts.Add(new("maxResults", mr.ToString(CultureInfo.InvariantCulture)));
-            }
-        }
-
-        foreach ((string key, string value) in req.AdditionalParameters)
-        {
-            parts.Add(new(key, value));
-        }
-
-        return Encode(parts);
-    }
-
-    private static void Validate(QueryRequest req)
-    {
-        if (req.Ids.Count > 0 && !string.IsNullOrWhiteSpace(req.GeneralSearch))
-        {
-            throw new InvalidOperationException("Cannot combine WithIds() and GeneralSearch().");
-        }
-
-        if (req.Page is { MaxResults: int mr } && mr <= 0)
-        {
-            throw new ArgumentException("Take must be > 0.");
-        }
-
-        if (req.Page is { FirstResult: int fr } && fr < 0)
-        {
-            throw new ArgumentException("Skip must be >= 0.");
-        }
-
-        // Enforce Page() semantics - Page() without Take() is a no-op and should fail
-        // Detect conflicts only within same field & target
-        IEnumerable<IGrouping<(FieldTarget Target, string Field), Filter>> groups = req.Filters
-            .GroupBy(f => (f.Target, f.Field))
-            .Where(g => g.Count() > 1);
-
-        foreach (IGrouping<(FieldTarget Target, string Field), Filter>? g in groups)
-        {
-            List<Op> ops = [.. g.Select(x => x.Operator)];
-            if (HasConflicts(ops))
-            {
-                throw new InvalidOperationException($"Conflicting filters for '{g.Key.Target}:{g.Key.Field}': {string.Join(", ", ops)}");
-            }
-        }
-    }
-
-    private static bool HasConflicts(List<Op> ops)
-    {
-        // No duplicates allowed
-        if (ops.Count != ops.Distinct().Count())
-        {
-            return true;
-        }
-
-        HashSet<Op> opsSet = [.. ops];
-
-        // Eq is mutually exclusive with any other operator
-        if (opsSet.Contains(Op.Eq) && opsSet.Count > 1)
-        {
-            return true;
-        }
-
-        // Ne is mutually exclusive with exact likes
-        if (opsSet.Contains(Op.Ne) && opsSet.Overlaps([Op.LikeExact, Op.ILikeExact]))
-        {
-            return true;
-        }
-
-        // Cannot mix Like and comparison operators
-        bool anyLike = opsSet.Overlaps(_likeOps);
-        bool anyCmp = opsSet.Overlaps(_comparisonOps);
-        if (anyLike && anyCmp)
-        {
-            return true;
-        }
-
-        // Allow at most one "greater than" type and one "less than" type
-        int gtCount = opsSet.Count(o => o is Op.Gt or Op.Ge);
-        int ltCount = opsSet.Count(o => o is Op.Lt or Op.Le);
-
-        if (gtCount > 1 || ltCount > 1)
-        {
-            return true;
-        }
-
-        return false;
-    }
-
-    private static string Encode(IEnumerable<KeyValuePair<string, string>> pairs)
-    {
-        static string E(string s) => Uri.EscapeDataString(s);
-        StringBuilder sb = new();
-        foreach ((string k, string v) in pairs)
-        {
-            if (sb.Length > 0)
-            {
-                sb.Append('&');
-            }
-
-            sb.Append(E(k)).Append('=').Append(E(v));
-        }
-        return sb.ToString();
-    }
-}

--- a/src/ume-app-estateservice/Umea.se.EstateService.ServiceAccess/Pythagoras/Api/QueryRequest.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.ServiceAccess/Pythagoras/Api/QueryRequest.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Immutable;
+
+namespace Umea.se.EstateService.ServiceAccess.Pythagoras.Api;
+
+public sealed record QueryRequest
+{
+    public ImmutableList<int> Ids { get; init; } = [];
+    public string? GeneralSearch { get; init; }
+    public ImmutableList<Filter> Filters { get; init; } = [];
+    public Order? OrderBy { get; init; }
+    public Paging? Page { get; init; }
+    public ImmutableDictionary<string, string> AdditionalParameters { get; init; } = ImmutableDictionary<string, string>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase);
+}

--- a/src/ume-app-estateservice/Umea.se.EstateService.ServiceAccess/Pythagoras/BuildingSearchResult.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.ServiceAccess/Pythagoras/BuildingSearchResult.cs
@@ -1,0 +1,12 @@
+namespace Umea.se.EstateService.ServiceAccess.Pythagoras;
+
+public sealed class BuildingSearchResult
+{
+    public int Id { get; init; }
+
+    public Guid? Uid { get; init; }
+
+    public string Name { get; init; } = string.Empty;
+
+    public string? PopularName { get; init; }
+}

--- a/src/ume-app-estateservice/Umea.se.EstateService.ServiceAccess/Pythagoras/Enum/Op.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.ServiceAccess/Pythagoras/Enum/Op.cs
@@ -1,0 +1,8 @@
+﻿namespace Umea.se.EstateService.ServiceAccess.Pythagoras.Enum;
+
+public enum Op
+{
+    Eq, Ne, Gt, Ge, Lt, Le,
+    LikeExact, LikeAnywhere, LikeStarts, LikeEnds,
+    ILikeExact, ILikeAnywhere, ILikeStarts, ILikeEnds
+}

--- a/src/ume-app-estateservice/Umea.se.EstateService.ServiceAccess/Pythagoras/Helpers/OperatorMaps.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.ServiceAccess/Pythagoras/Helpers/OperatorMaps.cs
@@ -1,0 +1,53 @@
+﻿using Umea.se.EstateService.ServiceAccess.Pythagoras.Enum;
+
+namespace Umea.se.EstateService.ServiceAccess.Pythagoras.Helpers;
+
+public static class OperatorMaps
+{
+    private static readonly Dictionary<Op, string> _prefix = new()
+    {
+        [Op.Eq] = "EQ:",
+        [Op.Ne] = "NE:",
+        [Op.Gt] = "GT:",
+        [Op.Ge] = "GE:",
+        [Op.Lt] = "LT:",
+        [Op.Le] = "LE:",
+        [Op.LikeExact] = "LIKEEX:",
+        [Op.LikeAnywhere] = "LIKEAW:",
+        [Op.LikeStarts] = "LIKEST:",
+        [Op.LikeEnds] = "LIKEEN:",
+        [Op.ILikeExact] = "ILIKEEX:",
+        [Op.ILikeAnywhere] = "ILIKEAW:",
+        [Op.ILikeStarts] = "ILIKEST:",
+        [Op.ILikeEnds] = "ILIKEEN:",
+    };
+
+    public static string ToPrefix(Op op) => _prefix[op];
+
+    public static Op FromStringOrPrefix(string op)
+    {
+        string u = op.Trim().ToUpperInvariant().TrimEnd(':');
+        if (u.Length == 0)
+        {
+            throw new ArgumentException("Operator cannot be empty.", nameof(op));
+        }
+        return u switch
+        {
+            "EQ" or "==" or "=" => Op.Eq,
+            "NE" or "!=" => Op.Ne,
+            "GT" or ">" => Op.Gt,
+            "GE" or ">=" => Op.Ge,
+            "LT" or "<" => Op.Lt,
+            "LE" or "<=" => Op.Le,
+            "LIKEEX" => Op.LikeExact,
+            "LIKEAW" => Op.LikeAnywhere,
+            "LIKEST" => Op.LikeStarts,
+            "LIKEEN" => Op.LikeEnds,
+            "ILIKEEX" => Op.ILikeExact,
+            "ILIKEAW" => Op.ILikeAnywhere,
+            "ILIKEST" => Op.ILikeStarts,
+            "ILIKEEN" => Op.ILikeEnds,
+            _ => throw new ArgumentException($"Unknown or unsupported operator '{u}'.", nameof(op))
+        };
+    }
+}

--- a/src/ume-app-estateservice/Umea.se.EstateService.ServiceAccess/Pythagoras/Helpers/PythagorasQueryHelpers.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.ServiceAccess/Pythagoras/Helpers/PythagorasQueryHelpers.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Concurrent;
+using System.Globalization;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Umea.se.EstateService.ServiceAccess.Pythagoras.Helpers;
+
+internal static class PythagorasQueryHelpers<T> where T : class
+{
+    private static readonly ConcurrentDictionary<PropertyInfo, string> _nameCache = new();
+
+    internal static string GetApiName<TProp>(Expression<Func<T, TProp>> expr)
+    {
+        PropertyInfo mi = expr.Body switch
+        {
+            MemberExpression m when m.Member is PropertyInfo pi => pi,
+            UnaryExpression u when u.Operand is MemberExpression um && um.Member is PropertyInfo upi => upi,
+            _ => throw new ArgumentException($"Expression must be a property access on {typeof(T).Name}.", nameof(expr))
+        };
+
+        return _nameCache.GetOrAdd(mi, static m =>
+        {
+            JsonPropertyNameAttribute? json = m.GetCustomAttribute<JsonPropertyNameAttribute>();
+            return json?.Name ?? JsonNamingPolicy.CamelCase.ConvertName(m.Name);
+        });
+    }
+
+    internal static string FormatValue<TProp>(TProp value)
+    {
+        if (value is null)
+        {
+            return string.Empty;
+        }
+
+        return value switch
+        {
+            DateTime dt => dt.Kind == DateTimeKind.Unspecified
+                ? DateTime.SpecifyKind(dt, DateTimeKind.Utc).ToString("o", CultureInfo.InvariantCulture)
+                : dt.ToString("o", CultureInfo.InvariantCulture),
+            DateTimeOffset dto => dto.ToString("o", CultureInfo.InvariantCulture),
+            bool b => b ? "true" : "false",
+            IFormattable f => f.ToString(null, CultureInfo.InvariantCulture) ?? string.Empty,
+            _ => value.ToString() ?? string.Empty
+        };
+    }
+}

--- a/src/ume-app-estateservice/Umea.se.EstateService.ServiceAccess/Pythagoras/Helpers/QueryStringWriter.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.ServiceAccess/Pythagoras/Helpers/QueryStringWriter.cs
@@ -1,0 +1,186 @@
+﻿using System.Globalization;
+using System.Text;
+using Umea.se.EstateService.ServiceAccess.Pythagoras.Api;
+using Umea.se.EstateService.ServiceAccess.Pythagoras.Enum;
+
+namespace Umea.se.EstateService.ServiceAccess.Pythagoras.Helpers;
+
+internal static class QueryStringWriter
+{
+    private static readonly HashSet<string> _reservedKeys = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "id[]", "generalSearch", "pN[]", "pV[]", "aN[]", "aV[]",
+        "orderBy", "orderAsc", "firstResult", "maxResults"
+    };
+
+    private static readonly HashSet<Op> _likeOps =
+    [
+        Op.LikeExact,
+        Op.LikeAnywhere,
+        Op.LikeStarts,
+        Op.LikeEnds,
+        Op.ILikeExact,
+        Op.ILikeAnywhere,
+        Op.ILikeStarts,
+        Op.ILikeEnds
+    ];
+
+    private static readonly HashSet<Op> _comparisonOps =
+    [
+        Op.Gt,
+        Op.Ge,
+        Op.Lt,
+        Op.Le
+    ];
+
+    internal static bool IsReservedKey(string key) => _reservedKeys.Contains(key);
+
+    internal static string Build(QueryRequest req)
+    {
+        Validate(req);
+
+        List<KeyValuePair<string, string>> parts = [];
+
+        foreach (int id in req.Ids)
+        {
+            parts.Add(new("id[]", id.ToString(CultureInfo.InvariantCulture)));
+        }
+
+        if (!string.IsNullOrWhiteSpace(req.GeneralSearch))
+        {
+            parts.Add(new("generalSearch", req.GeneralSearch!));
+        }
+
+        foreach (Filter f in req.Filters)
+        {
+            string prefixedName = $"{OperatorMaps.ToPrefix(f.Operator)}{f.Field}";
+            if (f.Target == FieldTarget.Parameter)
+            {
+                parts.Add(new("pN[]", prefixedName));
+                parts.Add(new("pV[]", f.Value));
+            }
+            else
+            {
+                parts.Add(new("aN[]", prefixedName));
+                parts.Add(new("aV[]", f.Value));
+            }
+        }
+
+        if (req.OrderBy is not null)
+        {
+            parts.Add(new("orderBy", req.OrderBy.Field));
+            parts.Add(new("orderAsc", req.OrderBy.Asc ? "true" : "false"));
+        }
+
+        if (req.Page is not null)
+        {
+            if (req.Page.FirstResult is int fr)
+            {
+                parts.Add(new("firstResult", fr.ToString(CultureInfo.InvariantCulture)));
+            }
+
+            if (req.Page.MaxResults is int mr)
+            {
+                parts.Add(new("maxResults", mr.ToString(CultureInfo.InvariantCulture)));
+            }
+        }
+
+        foreach ((string key, string value) in req.AdditionalParameters)
+        {
+            parts.Add(new(key, value));
+        }
+
+        return Encode(parts);
+    }
+
+    private static void Validate(QueryRequest req)
+    {
+        if (req.Ids.Count > 0 && !string.IsNullOrWhiteSpace(req.GeneralSearch))
+        {
+            throw new InvalidOperationException("Cannot combine WithIds() and GeneralSearch().");
+        }
+
+        if (req.Page is { MaxResults: int mr } && mr <= 0)
+        {
+            throw new ArgumentException("Take must be > 0.");
+        }
+
+        if (req.Page is { FirstResult: int fr } && fr < 0)
+        {
+            throw new ArgumentException("Skip must be >= 0.");
+        }
+
+        // Enforce Page() semantics - Page() without Take() is a no-op and should fail
+        // Detect conflicts only within same field & target
+        IEnumerable<IGrouping<(FieldTarget Target, string Field), Filter>> groups = req.Filters
+            .GroupBy(f => (f.Target, f.Field))
+            .Where(g => g.Count() > 1);
+
+        foreach (IGrouping<(FieldTarget Target, string Field), Filter>? g in groups)
+        {
+            List<Op> ops = [.. g.Select(x => x.Operator)];
+            if (HasConflicts(ops))
+            {
+                throw new InvalidOperationException($"Conflicting filters for '{g.Key.Target}:{g.Key.Field}': {string.Join(", ", ops)}");
+            }
+        }
+    }
+
+    private static bool HasConflicts(List<Op> ops)
+    {
+        // No duplicates allowed
+        if (ops.Count != ops.Distinct().Count())
+        {
+            return true;
+        }
+
+        HashSet<Op> opsSet = [.. ops];
+
+        // Eq is mutually exclusive with any other operator
+        if (opsSet.Contains(Op.Eq) && opsSet.Count > 1)
+        {
+            return true;
+        }
+
+        // Ne is mutually exclusive with exact likes
+        if (opsSet.Contains(Op.Ne) && opsSet.Overlaps([Op.LikeExact, Op.ILikeExact]))
+        {
+            return true;
+        }
+
+        // Cannot mix Like and comparison operators
+        bool anyLike = opsSet.Overlaps(_likeOps);
+        bool anyCmp = opsSet.Overlaps(_comparisonOps);
+        if (anyLike && anyCmp)
+        {
+            return true;
+        }
+
+        // Allow at most one "greater than" type and one "less than" type
+        int gtCount = opsSet.Count(o => o is Op.Gt or Op.Ge);
+        int ltCount = opsSet.Count(o => o is Op.Lt or Op.Le);
+
+        if (gtCount > 1 || ltCount > 1)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static string Encode(IEnumerable<KeyValuePair<string, string>> pairs)
+    {
+        static string E(string s) => Uri.EscapeDataString(s);
+        StringBuilder sb = new();
+        foreach ((string k, string v) in pairs)
+        {
+            if (sb.Length > 0)
+            {
+                sb.Append('&');
+            }
+
+            sb.Append(E(k)).Append('=').Append(E(v));
+        }
+        return sb.ToString();
+    }
+}

--- a/src/ume-app-estateservice/Umea.se.EstateService.ServiceAccess/Pythagoras/WorkspaceSearchResult.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.ServiceAccess/Pythagoras/WorkspaceSearchResult.cs
@@ -1,16 +1,5 @@
 namespace Umea.se.EstateService.ServiceAccess.Pythagoras;
 
-public sealed class BuildingSearchResult
-{
-    public int Id { get; init; }
-
-    public Guid? Uid { get; init; }
-
-    public string Name { get; init; } = string.Empty;
-
-    public string? PopularName { get; init; }
-}
-
 public sealed class WorkspaceSearchResult
 {
     public int Id { get; init; }

--- a/src/ume-app-estateservice/Umea.se.EstateService.Test/Pythagoras/BuildingControllerTests.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.Test/Pythagoras/BuildingControllerTests.cs
@@ -25,7 +25,7 @@ public class BuildingControllerTests
 
         IReadOnlyList<BuildingModel> buildings = await controller.GetBuildingsAsync(CancellationToken.None);
 
-        buildings.Select(b => b.Id).ShouldBe(new[] { 1, 2 });
+        buildings.Select(b => b.Id).ShouldBe([1, 2]);
         client.LastQueryString.ShouldBe("maxResults=50");
         client.LastEndpoint.ShouldBe("rest/v1/building");
     }

--- a/src/ume-app-estateservice/Umea.se.EstateService.Test/Pythagoras/PythagorasQueryTests.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.Test/Pythagoras/PythagorasQueryTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Umea.se.EstateService.ServiceAccess.Pythagoras.Api;
+using Umea.se.EstateService.ServiceAccess.Pythagoras.Enum;
 
 namespace Umea.se.EstateService.Test.Pythagoras;
 

--- a/src/ume-app-estateservice/Umea.se.EstateService.Test/Pythagoras/PythagorasServiceTests.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.Test/Pythagoras/PythagorasServiceTests.cs
@@ -51,7 +51,7 @@ public class PythagorasHandlerTests
         client.LastQuery.ShouldBeNull();
         client.LastPageSize.ShouldBe(10);
         client.LastCancellationToken.ShouldBe(cts.Token);
-        collected.Select(b => b.Id).ShouldBe(new[] { 1, 2 });
+        collected.Select(b => b.Id).ShouldBe([1, 2]);
     }
 
     [Fact]


### PR DESCRIPTION
Refactored `PythagorasHandler`, `PythagorasClient`, and `PythagorasQuery` to improve modularity and maintainability. Removed obsolete methods and redundant code. Introduced helper classes (`PythagorasQueryHelpers`, `QueryStringWriter`, `OperatorMaps`) and new enums/records (`Op`, `QueryRequest`, `BuildingSearchResult`).

Updated test cases to use concise syntax and reflect changes. Consolidated functionality into separate files, improving readability and reducing duplication.