### PR TITLE
Refactor tests and enhance DTO support in FakeClient

### DIFF
--- a/src/ume-app-estateservice/Umea.se.EstateService.Logic/Mappers/PythagorasBuildingInfoMapper.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.Logic/Mappers/PythagorasBuildingInfoMapper.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Umea.se.EstateService.ServiceAccess.Pythagoras.Dto;
-using Umea.se.EstateService.ServiceAccess.Pythagoras.Enum;
 using Umea.se.EstateService.Shared.Models;
 using Umea.se.EstateService.Shared.ValueObjects;
 using TransportMarkerType = Umea.se.EstateService.ServiceAccess.Pythagoras.Enum.PythMarkerType;

--- a/src/ume-app-estateservice/Umea.se.EstateService.ServiceAccess/Pythagoras/Dto/BuildingInfo.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.ServiceAccess/Pythagoras/Dto/BuildingInfo.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using Umea.se.EstateService.ServiceAccess.Pythagoras.Enum;
 
 namespace Umea.se.EstateService.ServiceAccess.Pythagoras.Dto;

--- a/src/ume-app-estateservice/Umea.se.EstateService.Test/Pythagoras/EstateControllerTests.cs
+++ b/src/ume-app-estateservice/Umea.se.EstateService.Test/Pythagoras/EstateControllerTests.cs
@@ -29,7 +29,7 @@ public class EstateControllerTests
         buildings.Select(b => b.Id).ShouldBe(new[] { 10, 11 });
         client.LastQueryString.ShouldNotBeNull();
         client.LastQueryString.ShouldContain("navigationFolderId=123");
-        client.LastEndpoint.ShouldBe("rest/v1/building");
+        client.LastEndpoint.ShouldBe("rest/v1/building/info");
     }
 
     [Fact]
@@ -48,7 +48,7 @@ public class EstateControllerTests
         buildings.ShouldBeEmpty();
         client.LastQueryString.ShouldNotBeNull();
         client.LastQueryString.ShouldContain("navigationFolderId=456");
-        client.LastEndpoint.ShouldBe("rest/v1/building");
+        client.LastEndpoint.ShouldBe("rest/v1/building/info");
     }
 
     private sealed class FakePythagorasClient : IPythagorasClient
@@ -59,15 +59,88 @@ public class EstateControllerTests
 
         public Task<IReadOnlyList<TDto>> GetAsync<TDto>(string endpoint, PythagorasQuery<TDto>? query, CancellationToken cancellationToken) where TDto : class
         {
-            if (typeof(TDto) != typeof(Building))
-            {
-                throw new NotSupportedException("Test fake only supports Building DTOs.");
-            }
-
             LastEndpoint = endpoint;
             LastQueryString = query?.BuildAsQueryString();
 
-            return Task.FromResult((IReadOnlyList<TDto>)(object)GetAsyncResult);
+            if (typeof(TDto) == typeof(Building))
+            {
+                return Task.FromResult((IReadOnlyList<TDto>)(object)GetAsyncResult);
+            }
+            if (typeof(TDto) == typeof(BuildingInfoModel))
+            {
+                List<BuildingInfoModel> mapped = GetAsyncResult
+                    .Select(b => new BuildingInfoModel
+                    {
+                        Id = b.Id,
+                        Uid = b.Uid,
+                        Name = b.Name,
+                        PopularName = b.PopularName,
+                        MarkerType = (MarkerTypeEnum)(int)b.MarkerType,
+                        GeoLocation = null,
+                        Origin = b.Origin,
+                        // The rest are not present in Building, so use defaults:
+                        GrossArea = 0,
+                        NetArea = 0,
+                        SumGrossFloorArea = 0,
+                        NumPlacedPersons = 0,
+                        AddressName = string.Empty,
+                        Address = null,
+                        CurrencyId = null,
+                        CurrencyName = null,
+                        FlagStatusIds = Array.Empty<int>(),
+                        BusinessTypeId = null,
+                        BusinessTypeName = null,
+                        ProspectOfBuildingId = null,
+                        IsProspect = false,
+                        ProspectStartDate = null,
+                        ExtraInfo = new Dictionary<string, string?>(),
+                        PropertyValues = new Dictionary<string, string?>(),
+                        NavigationInfo = new Dictionary<string, string?>()
+                    })
+                    .ToList();
+                return Task.FromResult((IReadOnlyList<TDto>)(object)mapped);
+            }
+            if (typeof(TDto) == typeof(BuildingInfo))
+            {
+                List<BuildingInfo> mapped = GetAsyncResult
+                    .Select(b => new BuildingInfo
+                    {
+                        Id = b.Id,
+                        Uid = b.Uid,
+                        Name = b.Name,
+                        PopularName = b.PopularName,
+                        MarkerType = b.MarkerType,
+                        Grossarea = null,
+                        Netarea = null,
+                        SumGrossFloorarea = null,
+                        NumPlacedPersons = 0,
+                        GeoX = b.GeoLocation?.X ?? 0,
+                        GeoY = b.GeoLocation?.Y ?? 0,
+                        GeoRotation = b.GeoLocation?.Rotation ?? 0,
+                        AddressName = string.Empty,
+                        AddressCity = string.Empty,
+                        AddressCountry = string.Empty,
+                        AddressStreet = string.Empty,
+                        AddressZipCode = string.Empty,
+                        AddressExtra = string.Empty,
+                        Origin = b.Origin,
+                        CurrencyId = null,
+                        CurrencyName = null,
+                        FlagStatusIds = Array.Empty<int>(),
+                        BusinessTypeId = null,
+                        BusinessTypeName = null,
+                        ProspectOfBuildingId = null,
+                        IsProspect = false,
+                        ProspectStartDate = null,
+                        ExtraInfo = [],
+                        PropertyValues = [],
+                        NavigationInfo = []
+                    })
+                    .ToList();
+                return Task.FromResult((IReadOnlyList<TDto>)(object)mapped);
+            }
+
+            throw new NotSupportedException("Test fake only supports Building, BuildingInfo, and BuildingInfoModel DTOs.");
         }
 
         public IAsyncEnumerable<TDto> GetPaginatedAsync<TDto>(string endpoint, PythagorasQuery<TDto>? query, int pageSize, CancellationToken cancellationToken) where TDto : class


### PR DESCRIPTION
Removed unused `using` directives in `PythagorasBuildingInfoMapper.cs` and `BuildingInfo.cs` for cleaner code. Updated test expectations in `EstateControllerTests.cs` to reflect the new API endpoint (`rest/v1/building/info`).

Enhanced `FakePythagorasClient` to support `BuildingInfoModel` and `BuildingInfo` DTOs, with detailed property mapping and default values for missing fields. Refactored the `GetAsync` method to handle multiple DTO types and throw `NotSupportedException` for unsupported types.

Improved test coverage and reliability by simulating responses for additional DTOs, making the test infrastructure more extensible and maintainable.


Kolla gärna lastendpointgrejen @ume-nichlas 